### PR TITLE
Make one error message a little more user friendly.

### DIFF
--- a/bin/git-spelunk
+++ b/bin/git-spelunk
@@ -25,7 +25,8 @@ end
 
 options = parse_options(ARGV)
 
-raise "Too many arguments" if ARGV.size != 1
+raise "No filename specified. You must provide a file to blame-on." if ARGV.size == 0
+raise "Too many arguments" if ARGV.size > 1
 
 file = ARGV[0]
 


### PR DESCRIPTION
```
ZiggyPiggy:git-spelunk jstillwell$ ./bin/git-spelunk 
./bin/git-spelunk:28:in `<main>': No filename specified. You must provide a file to blame-on. (RuntimeError)
```

```
ZiggyPiggy:git-spelunk jstillwell$ ./bin/git-spelunk ads asdfasf adsf
./bin/git-spelunk:29:in `<main>': Too many arguments (RuntimeError)
```