### PR TITLE
[WIP] Replace grit with rugged to blame

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,11 @@ PATH
   remote: .
   specs:
     git_spelunk (0.4.1)
+      byebug
       curses
       dispel
       grit
+      rugged
 
 GEM
   remote: https://rubygems.org/
@@ -13,15 +15,15 @@ GEM
     byebug (5.0.0)
       columnize (= 0.9.0)
     columnize (0.9.0)
-    curses (1.0.1)
+    curses (1.2.7)
     debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
       debugger-ruby_core_source (~> 1.3.5)
     debugger-linecache (1.2.0)
     debugger-ruby_core_source (1.3.8)
-    diff-lcs (1.2.5)
-    dispel (0.0.7)
+    diff-lcs (1.3)
+    dispel (0.1.0)
       curses
     grit (2.5.0)
       diff-lcs (~> 1.1)
@@ -31,8 +33,9 @@ GEM
     minitest (5.6.1)
     minitest-rg (5.1.0)
       minitest (~> 5.0)
-    posix-spawn (0.3.11)
+    posix-spawn (0.3.13)
     rake (10.4.2)
+    rugged (0.28.1)
 
 PLATFORMS
   ruby
@@ -47,4 +50,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/git_spelunk.gemspec
+++ b/git_spelunk.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("grit")
   s.add_runtime_dependency("dispel")
   s.add_runtime_dependency("curses")
+  s.add_runtime_dependency("rugged")
+  s.add_runtime_dependency('byebug')
 
   s.files = `git ls-files lib bin MIT-LICENSE.txt`.split("\n")
   s.license = "MIT"

--- a/lib/git_spelunk.rb
+++ b/lib/git_spelunk.rb
@@ -4,3 +4,5 @@ require 'git_spelunk/file_context'
 require 'git_spelunk/offset'
 require 'git_spelunk/grit_patches'
 
+require 'rugged'
+require 'byebug'

--- a/lib/git_spelunk/blame.rb
+++ b/lib/git_spelunk/blame.rb
@@ -2,32 +2,64 @@ module GitSpelunk
   BlameLine = Struct.new(:line_number, :old_line_number, :sha, :commit, :filename, :content)
   class EmptyBlame < StandardError ; end
   class Blame < Grit::Blame
+    def rugged_blame(repo_path, file_path, options={})
+      repo = Rugged::Repository.discover(repo_path || './')
+      blame = Rugged::Blame.new(repo, file_path)#, newest_commit: '31d7fed5')
+      return repo, blame
+    end
+
     def process_raw_blame(output)
       lines = []
       commits = {}
       commit_file_map = {}
+      path = 'lib/git_spelunk/blame.rb'
+      repo, r_blame = rugged_blame('./', path)
 
-      raise EmptyBlame.new if output.empty?
+       # raise EmptyBlame.new if output.empty?
 
-      split_output = output.split(/^(\w{40} \d+ \d+(?: \d+)?\n)/m)
-      split_output.shift if split_output.first.empty?
+       # split_output = output.split(/^(\w{40} \d+ \d+(?: \d+)?\n)/m)
+       # split_output.shift if split_output.first.empty?
 
-      lines = split_output.each_slice(2).map do |sha_line, rest|
-        sha_split = sha_line.split(' ')
+      total_lines = r_blame.to_a.inject(0) {|s, l| s + l[:lines_in_hunk]}
+      lines = []
 
-        sha, old_lineno, lineno = sha_split[0], sha_split[1].to_i, sha_split[2].to_i
+      (1..total_lines).each do |i|
+        hunk = r_blame.for_line(i)
+      #lines = r_blame.each.map do |hunk|
+        #lines = split_output.each_slice(2).map do |sha_line, rest|
+        sha = hunk[:final_commit_id]
+        old_lineno = hunk[:orig_start_line_number]
+        lineno = hunk[:final_start_line_number]
+        #sha_split = sha_line.split(' ')
+        #sha, old_lineno, lineno = sha_split[0], sha_split[1].to_i, sha_split[2].to_i
 
         # indicate we need to fetch this sha in the bulk-fetch
         commits[sha] = nil
 
-        if rest =~ /^filename (.*)$/
-          commit_file_map[sha] = $1
+        #if rest =~ /^filename (.*)$/
+        #  commit_file_map[sha] = $1
+        #end
+        commit_file_map[sha] = hunk[:orig_path]
+
+        #data = rest.split("\n").detect { |l| l[0] == "\t" }[1..-1]
+        tree_route = hunk[:orig_path].split("/")
+        node_sha = sha
+        target = nil
+        tree_route << ''
+        tree_route.each do |node|
+          obj = repo.lookup(node_sha)
+          case obj
+          when Rugged::Tree
+            node_sha = obj[node][:oid]
+          when Rugged::Commit
+            node_sha = obj.tree[node][:oid]
+          when Rugged::Blob
+            target = obj
+          end
         end
-
-        data = rest.split("\n").detect { |l| l[0] == "\t" }[1..-1]
-        { :data => data, :sha => sha, :filename => commit_file_map[sha], :old_line_number => old_lineno, :line_number => lineno }
+        data = target.content.split("\n")
+        lines << { :data => data[i-1], :sha => sha, :filename => commit_file_map[sha], :old_line_number => old_lineno, :line_number => lineno }
       end
-
 
       # load all commits in single call
       @repo.batch(*commits.keys).each do |commit|


### PR DESCRIPTION
🚧 

This is not easy as I expected. Replacing grit with rugged completely is a hell lot of change which pretty much means rewriting the whole lib.  So I'm thinking of patching the raw blame part, and still let grit do the rest of the work. A bit nasty, but probably the least effort.

What do you think? @osheroff 

The code is only a demonstration... does not work properly atm..