### PR TITLE
Fix color config problems

### DIFF
--- a/lib/git_spelunk/ui.rb
+++ b/lib/git_spelunk/ui.rb
@@ -165,7 +165,7 @@ Date: #{info[:date]}
           when 's'
             sha = @pager.blame_line.sha
             Curses.close_screen
-            system("git -p --git-dir='#{@file_context.repo.path}' show #{sha} | less")
+            system("git -p --git-dir='#{@file_context.repo.path}' show #{sha} | less -R")
           when '/', '?'
             @status.command_buffer = key
             @typing = :search

--- a/lib/git_spelunk/ui.rb
+++ b/lib/git_spelunk/ui.rb
@@ -80,7 +80,7 @@ Date: #{info[:date]}
     def history_back
       @status.set_onetime_message("Rewinding...")
       goto = @file_context.get_line_for_sha_parent(@pager.blame_line)
-      if goto.is_a?(Fixnum)
+      if goto.is_a?(Integer)
         @file_context.line_number = @pager.cursor
         @history.push(@file_context)
 


### PR DESCRIPTION
In my `~/.gitconfig` I have (among many, many other things) this bit
```
[color]
  ui = always
```

~Unfortunately `grit` respects this setting when creating a `diff`, which makes git-spelunk sometimes crash when going back through history.~ Rugged ignores this setting.

Also when I click `s` to see a specific commit, I get ANSI escape codes all over the screen. I thought this would be best fixed by simply piping into a pager that understands ANSI (`less -R`). I have not checked what happens if the commit you are looking at _itself_ contains ANSI color codes, and your gitconfig does _not_ set colors always on. Will `less -R` mess everything up? I don’t know.